### PR TITLE
Gamestate Fixes for the New Colonist UI

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,6 @@
   "tabWidth": 2,
   "useTabs": false,
   "bracketSpacing": true,
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "endOfLine": "crlf"
 }

--- a/src/__tests__/scenarios/initialResources.html
+++ b/src/__tests__/scenarios/initialResources.html
@@ -19,8 +19,8 @@ and the bank should have the following resources: 18 ore, 18 sheep, 16 wheat, 17
 <html>
   <body>
     <p
-      class="header_profile_username"
-      id="header_profile_username"
+      class="web-header-username"
+      id="web-header-username"
       style="font-weight: bold"
     >
       NickTheSwift

--- a/src/__tests__/scenarios/stealButWithOnlyOneTypeOfResources.html
+++ b/src/__tests__/scenarios/stealButWithOnlyOneTypeOfResources.html
@@ -6,8 +6,8 @@
 <html>
   <body>
     <p
-      class="header_profile_username"
-      id="header_profile_username"
+      class="web-header-username"
+      id="web-header-username"
       style="font-weight: bold"
     >
       NickTheSwift

--- a/src/__tests__/scenarios/stealTracker.html
+++ b/src/__tests__/scenarios/stealTracker.html
@@ -10,8 +10,8 @@ and the bank should have the following resources: 17 ore, 17 sheep, 12 wheat, 18
 <html>
   <body>
     <p
-      class="header_profile_username"
-      id="header_profile_username"
+      class="web-header-username"
+      id="web-header-username"
       style="font-weight: bold"
     >
       NickTheSwift

--- a/src/chatParser.ts
+++ b/src/chatParser.ts
@@ -60,6 +60,29 @@ function ignoreElement(element: HTMLElement, messageText: string): boolean {
   );
 }
 
+/**
+ * Checks if an element represents a duplicate chat message
+ * This can be solved in a greedy fashion by checking the chat number (data-index attribute) against the last processed chat number in game state
+ */
+function checkDuplicateElement(element: HTMLElement): boolean {
+  // Get ID from the element
+  const dataIndexAttr = element.attributes.getNamedItem('data-index');
+
+  // If no data-index attribute, treat as duplicate to be safe
+  if (!dataIndexAttr) return true;
+  const chatNumber = parseInt(dataIndexAttr.value);
+
+  // Check if this chat number has already been processed
+  if (chatNumber < game.chatsProcessed) {
+    console.log(`⏭️ Skipping already processed chat #${chatNumber}`);
+    return true;
+  }
+
+  // Update the last processed chat number
+  game.chatsProcessed = chatNumber;
+  return false;
+}
+
 export function updateGameFromChat(element: HTMLElement): void {
   // If we're waiting for "you" player selection, don't process new messages
   if (isWaitingForYouPlayerSelection) return;
@@ -67,6 +90,8 @@ export function updateGameFromChat(element: HTMLElement): void {
   const messageText = element.textContent?.replace(/\s+/g, ' ').trim() || '';
 
   if (ignoreElement(element, messageText)) return;
+
+  if (checkDuplicateElement(element)) return;
 
   let playerName = getPlayerName(element);
 

--- a/src/domUtils.ts
+++ b/src/domUtils.ts
@@ -47,7 +47,7 @@ export function getPlayerColor(element: HTMLElement): string {
 export function getCurrentPlayerFromHeader(): string | null {
   const headerElement = document.getElementById('web-header-username');
   if (!headerElement) {
-    console.log('🔍 header_profile_username element not found');
+    console.log('🔍 web-header-username element not found');
     return null;
   }
 
@@ -55,7 +55,7 @@ export function getCurrentPlayerFromHeader(): string | null {
   if (currentPlayer) {
     console.log(`🎯 Auto-detected current player: ${currentPlayer}`);
   } else {
-    console.log('🔍 header_profile_username element found but empty');
+    console.log('🔍 web-header-username element found but empty');
   }
 
   return currentPlayer;

--- a/src/domUtils.ts
+++ b/src/domUtils.ts
@@ -3,7 +3,7 @@ import { ResourceObjectType } from './types.js';
 export const RESOURCE_STRING =
   'img[alt="grain"], img[alt="wool"], img[alt="lumber"], img[alt="brick"], img[alt="ore"], img[alt="Grain"], img[alt="Wool"], img[alt="Lumber"], img[alt="Brick"], img[alt="Ore"]';
 
-export function findChatContainer(): HTMLDivElement | null {
+export function findChatContainer(): HTMLElement | null {
   const divs = document.querySelectorAll<HTMLDivElement>('div');
 
   for (const outerDiv of Array.from(divs)) {
@@ -16,7 +16,7 @@ export function findChatContainer(): HTMLDivElement | null {
             'a[href="#open-rulebook"]'
           );
           if (anchor) {
-            return outerDiv;
+            return outerDiv.parentElement;
           }
         }
       }
@@ -41,11 +41,11 @@ export function getPlayerColor(element: HTMLElement): string {
 }
 
 /**
- * Automatically detects the current player from the header profile username
+ * Automatically detects the current player from the web-header-username
  * This eliminates the need for user input popups
  */
 export function getCurrentPlayerFromHeader(): string | null {
-  const headerElement = document.getElementById('header_profile_username');
+  const headerElement = document.getElementById('web-header-username');
   if (!headerElement) {
     console.log('🔍 header_profile_username element not found');
     return null;

--- a/src/gameActions.ts
+++ b/src/gameActions.ts
@@ -4,6 +4,7 @@ import {
   game,
   updateResources,
 } from './gameState.js';
+import { showYouPlayerDialog } from './overlay.js';
 import { PropbableGameState } from './probableGameState.js';
 import {
   DiceRollsType,
@@ -72,8 +73,10 @@ export function rollDice(diceTotal: number): void {
         const success = autoDetectCurrentPlayer();
         if (!success) {
           console.log(
-            '⚠️ Could not auto-detect current player. Manual selection may be needed.'
+            '⚠️ Could not auto-detect current player. Manually asking for selection.'
           );
+          // Manually ask for player name
+          showYouPlayerDialog();
         }
       }
     }

--- a/src/gameState.ts
+++ b/src/gameState.ts
@@ -63,7 +63,7 @@ export function setYouPlayer(playerName: string): void {
 }
 
 /**
- * Automatically sets the current player from header_profile_username
+ * Automatically sets the current player from web-header-username
  * Returns true if successful, false otherwise
  */
 export function autoDetectCurrentPlayer(): boolean {

--- a/src/gameState.ts
+++ b/src/gameState.ts
@@ -12,6 +12,7 @@ export function getDefaultGame(): GameType {
   return {
     players: [],
     gameType: GameTypeEnum.STANDARD,
+    chatsProcessed: 0,
     gameResources: {
       sheep: 19,
       wheat: 19,

--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -839,3 +839,96 @@ export function updateGameStateDisplay(): void {
 export function setYouPlayerSelectedCallback(callback: () => void): void {
   youPlayerSelectedCallback = callback;
 }
+
+export function showYouPlayerDialog(): void {
+  if (game.players.length === 0) return;
+
+  // Mark that we've asked to prevent multiple dialogs
+  markYouPlayerAsked();
+
+  // Create modal backdrop
+  const backdrop = document.createElement('div');
+  backdrop.style.cssText = `
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 10001;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  `;
+
+  // Create dialog
+  const dialog = document.createElement('div');
+  dialog.style.cssText = `
+    background: white;
+    border-radius: 8px;
+    padding: 20px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    max-width: 400px;
+    width: 90%;
+    font-family: Arial, sans-serif;
+  `;
+
+  dialog.innerHTML = `
+    <h3 style="margin: 0 0 15px 0; color: #2c3e50;">🎲 Catan Counter Setup</h3>
+    <p style="margin: 0 0 20px 0; color: #555;">
+      Which player are you? This helps the extension track when resources are stolen "from you".
+    </p>
+    <div id="player-buttons" style="display: flex; flex-direction: column; gap: 10px;">
+      ${game.players
+        .map(
+          player => `
+        <button 
+          data-player="${player.name}" 
+          style="
+            padding: 12px; 
+            border: 2px solid #3498db; 
+            background: #ecf0f1; 
+            border-radius: 6px; 
+            cursor: pointer; 
+            font-weight: bold;
+            transition: all 0.2s;
+          "
+          onmouseover="this.style.background='#3498db'; this.style.color='white';"
+          onmouseout="this.style.background='#ecf0f1'; this.style.color='black';"
+        >
+          ${player.name}
+        </button>
+      `
+        )
+        .join('')}
+    </div>
+  `;
+
+  backdrop.appendChild(dialog);
+  document.body.appendChild(backdrop);
+
+  // Add click handlers
+  const buttons = dialog.querySelectorAll('[data-player]');
+  buttons.forEach(button => {
+    button.addEventListener('click', () => {
+      const playerName = button.getAttribute('data-player');
+      if (playerName) {
+        setYouPlayer(playerName);
+        console.log(`🎯 "You" player set to: ${playerName}`);
+        document.body.removeChild(backdrop);
+
+        // Trigger reprocessing callback if provided
+        if (youPlayerSelectedCallback) {
+          youPlayerSelectedCallback();
+        }
+      }
+    });
+  });
+
+  // Close on backdrop click
+  backdrop.addEventListener('click', e => {
+    if (e.target === backdrop) {
+      document.body.removeChild(backdrop);
+    }
+  });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export enum GameTypeEnum {
 export interface GameType {
   players: PlayerType[];
   gameType: GameTypeEnum;
+  chatsProcessed: number;
   gameResources: ResourceObjectType;
   devCards: number;
   knights: number;


### PR DESCRIPTION
I love the project, but it required a few fixes to work with the new UI Colonist.io uses.

Changes
- Updated the username ID (header_profile_username -> web-header-username).
- Updated tests to use the new username ID.
- Added functionality to ensure duplicate messages aren't processed. This is required due to Colonist.io now displaying 14 divs worth of messages at a time instead of a div for every message. So if you ever scrolled up the chat, it would reprocess those messages over and over, causing the tracker to have the wrong count.
- Reimplemented your dialogue box asking the user to select their username. This is only needed if the user refreshes the page, as the web-header-username div disappears.
- Forced prettier to use crlf to match your repo